### PR TITLE
Added environmental var replacements and tests

### DIFF
--- a/src/Remy.Core/Config/ConfigFileReader.cs
+++ b/src/Remy.Core/Config/ConfigFileReader.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Net;
-using Serilog;
 
 namespace Remy.Core.Config
 {
@@ -11,28 +10,64 @@ namespace Remy.Core.Config
 		{
 			if (uri.IsFile)
 			{
-			    try
-			    {
-			        return File.ReadAllText(uri.LocalPath);
-			    }
-                catch (IOException e)
-				{
-                    throw new RemyException($"Unable to download open file '{uri}' - {e.Message}", e);
-				}
+				string yaml = ReadLocalFile(uri);
+				yaml = ReplaceAllEnvironmentalVariables(yaml);
+
+				return yaml;
 			}
 			else if (uri.Scheme.StartsWith("http"))
 			{
-				try
-				{
-					return new WebClient().DownloadString(uri);
-				}
-				catch (WebException e)
-				{
-                    throw new RemyException($"Unable to download '{uri}' - {e.Message}", e);
-				}
+				string yaml = ReadRemoteFile(uri);
+				yaml = ReplaceAllEnvironmentalVariables(yaml);
+
+				return yaml;
 			}
 
 			throw new RemyException($"The scheme {uri.Scheme} for {uri} is not supported");
+		}
+
+		private string ReadLocalFile(Uri uri)
+		{
+			try
+			{
+				return File.ReadAllText(uri.LocalPath);
+			}
+			catch (IOException e)
+			{
+				throw new RemyException($"Unable to download open file '{uri}' - {e.Message}", e);
+			}
+		}
+
+		private string ReadRemoteFile(Uri uri)
+		{
+			try
+			{
+				return new WebClient().DownloadString(uri);
+			}
+			catch (WebException e)
+			{
+				throw new RemyException($"Unable to download '{uri}' - {e.Message}", e);
+			}
+		}
+
+		private string ReplaceAllEnvironmentalVariables(string yaml)
+		{
+			yaml = ReplaceEnvironmentalVariables(yaml, EnvironmentVariableTarget.User);
+			yaml = ReplaceEnvironmentalVariables(yaml, EnvironmentVariableTarget.Process);
+			yaml = ReplaceEnvironmentalVariables(yaml, EnvironmentVariableTarget.Machine);
+
+			return yaml;
+		}
+
+		private string ReplaceEnvironmentalVariables(string yaml, EnvironmentVariableTarget target)
+		{
+			var envVars = Environment.GetEnvironmentVariables(target);
+			foreach (string key in envVars.Keys)
+			{
+				yaml = yaml.Replace("{{" + key + "}}", envVars[key].ToString());
+			}
+
+			return yaml;
 		}
 
 	    public static string GetFullPathForFile(string filename)

--- a/src/Remy.Tests/Integration/Core/Config/ConfigFileReaderTests.cs
+++ b/src/Remy.Tests/Integration/Core/Config/ConfigFileReaderTests.cs
@@ -1,5 +1,12 @@
 ﻿using System;
 using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Nancy;
 using NUnit.Framework;
 using Remy.Core;
 using Remy.Core.Config;
@@ -8,7 +15,7 @@ namespace Remy.Tests.Integration.Core.Config
 {
 	[TestFixture]
 	public class ConfigFileReaderTests
-    {
+	{
 		[Test]
 		public void should_read_file_from_disk()
 		{
@@ -27,57 +34,117 @@ namespace Remy.Tests.Integration.Core.Config
 		public void should_read_file_from_url()
 		{
 			// Arrange
-			var fileReader = new ConfigFileReader();
+			string url = GetLocalhostAddress();
+
+			using (var task = RunBasicHttpServer(url, "- some yaml\n- more yaml"))
+			{
+				var fileReader = new ConfigFileReader();
+
+				// Act
+				string actualContent = fileReader.Read(new Uri(url));
+
+				// Assert
+				Assert.That(actualContent, Does.Contain("- some yaml\n- more yaml"));
+			}
+		}
+
+		[Test]
+		public void should_read_file_from_url_and_replace_env_vars()
+		{
+			// Arrange
+			string url = GetLocalhostAddress();
+
+			Environment.SetEnvironmentVariable("key1", "myvalue1", EnvironmentVariableTarget.Machine);
+			Environment.SetEnvironmentVariable("key2", "myvalue2", EnvironmentVariableTarget.Process);
+			Environment.SetEnvironmentVariable("key3", "myvalue3", EnvironmentVariableTarget.User);
+			Environment.SetEnvironmentVariable("key1", "user values trump machine values", EnvironmentVariableTarget.User);
+
+			using (var task = RunBasicHttpServer(url, "- some yaml {{key1}} {{key2}} {{key3}}"))
+			{
+				// Server
+				var fileReader = new ConfigFileReader();
+
+				// Act
+				string actualContent = fileReader.Read(new Uri(url));
+
+				// Assert
+				Assert.That(actualContent, Does.Contain("myvalue2"));
+				Assert.That(actualContent, Does.Contain("myvalue3"));
+				Assert.That(actualContent, Does.Contain("user values trump machine values"));
+			}
+		}
+
+		private string GetLocalhostAddress()
+		{
+			var listener = new TcpListener(IPAddress.Loopback, 0);
+			listener.Start();
+			int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+			listener.Stop();
+
+			return $"http://localhost:{port}/";
+		}
+
+		public static Task RunBasicHttpServer(string url, string outputHtml)
+		{
+			return Task.Run(() =>
+			{
+				HttpListener listener = new HttpListener();
+				listener.Prefixes.Add(url);
+				listener.Start();
+
+				// GetContext method blocks while waiting for a request. 
+				HttpListenerContext context = listener.GetContext();
+				HttpListenerResponse response = context.Response;
+
+				Stream stream = response.OutputStream;
+				var writer = new StreamWriter(stream);
+				writer.Write(outputHtml);
+				writer.Close();
+			});
+		}
+
+		[Test]
+		public void GetFullPathForFile_should_return_full_path_for_filename()
+		{
+			// Arrange
+			string expectedPath = Path.Combine(Directory.GetCurrentDirectory(), "myfile.txt");
 
 			// Act
-			string actualContent = fileReader.Read(new Uri("http://www.example.com"));
+			string actualPath = ConfigFileReader.GetFullPathForFile("myfile.txt");
 
 			// Assert
-			Assert.That(actualContent, Does.Contain("Example Domain"));
+			Assert.That(actualPath, Is.EqualTo(expectedPath));
 		}
 
-        [Test]
-        public void GetFullPathForFile_should_return_full_path_for_filename()
-        {
-            // Arrange
-            string expectedPath = Path.Combine(Directory.GetCurrentDirectory(), "myfile.txt");
-
-            // Act
-            string actualPath = ConfigFileReader.GetFullPathForFile("myfile.txt");
-
-            // Assert
-            Assert.That(actualPath, Is.EqualTo(expectedPath));
-        }
-
-        [Test]
+		[Test]
 		public void should_throw_remyexception_for_bad_filepath()
 		{
-            // Arrange
-            string configPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "doesnexist");
-            var fileReader = new ConfigFileReader();
+			// Arrange
+			string configPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "doesnexist");
+			var fileReader = new ConfigFileReader();
 
-            // Act + Assert
-		    Assert.Throws<RemyException>(() => fileReader.Read(new Uri(configPath)));
+			// Act + Assert
+			Assert.Throws<RemyException>(() => fileReader.Read(new Uri(configPath)));
 		}
 
-        [Test]
-        public void should_throw_remyexception_for_invalid_uri()
-        {
-            // Arrange
-            var fileReader = new ConfigFileReader();
+		[Test]
+		public void should_throw_remyexception_for_invalid_uri()
+		{
+			// Arrange
+			var fileReader = new ConfigFileReader();
 
-            // Act + Assert
-            Assert.Throws<RemyException>(() => fileReader.Read(new Uri("http://bleh")));
-        }
+			// Act + Assert
+			Assert.Throws<RemyException>(() => fileReader.Read(new Uri("http://bleh")));
+		}
 
-        [Test]
-        public void should_throw_remyexception_for_unsupported_scheme()
-        {
-            // Arrange
-            var fileReader = new ConfigFileReader();
+		[Test]
+		public void should_throw_remyexception_for_unsupported_scheme()
+		{
+			// Arrange
+			var fileReader = new ConfigFileReader();
 
-            // Act + Assert
-            Assert.Throws<RemyException>(() => fileReader.Read(new Uri("ftp://warezplace")));
-        }
-    }
+			// Act + Assert
+			Assert.Throws<RemyException>(() => fileReader.Read(new Uri("ftp://warezplace")));
+		}
+	}
 }

--- a/src/Remy.Tests/Remy.Tests.csproj
+++ b/src/Remy.Tests/Remy.Tests.csproj
@@ -36,8 +36,28 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Diagnostics, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Diagnostics.3.0.1\lib\net45\Microsoft.Owin.Diagnostics.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nancy, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Nancy.1.4.1\lib\net40\Nancy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -92,6 +112,10 @@
       <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.3.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
@@ -111,6 +135,16 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="YamlDotNet, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Remy.Tests/Unit/Core/Config/Yaml/ExampleYaml.cs
+++ b/src/Remy.Tests/Unit/Core/Config/Yaml/ExampleYaml.cs
@@ -45,7 +45,7 @@ tasks:
         value: ""xyz""
     ";
 
-        public const string DuplicateConfigKeys = @"
+		public const string DuplicateConfigKeys = @"
 name: ""Basic example""
 tasks:
   -

--- a/src/Remy.Tests/Unit/Core/Config/Yaml/YamlConfigParserTests.cs
+++ b/src/Remy.Tests/Unit/Core/Config/Yaml/YamlConfigParserTests.cs
@@ -106,7 +106,7 @@ namespace Remy.Tests.Unit.Core.Config.Yaml
             Assert.That(config.Config["KEY2"], Is.EqualTo("xyz"));
         }
 
-        [Test]
+		[Test]
         public void should_ignore_duplicate_config_keys()
         {
             // given

--- a/src/Remy.Tests/packages.config
+++ b/src/Remy.Tests/packages.config
@@ -3,7 +3,14 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net461" />
   <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net452" />
   <package id="coveralls.io" version="1.3.4" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net461" />
+  <package id="Microsoft.Owin.Diagnostics" version="3.0.1" targetFramework="net461" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net461" />
+  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net461" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net461" />
+  <package id="Nancy" version="1.4.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net461" />
   <package id="NuGet.Common" version="3.4.3" targetFramework="net461" />
   <package id="NuGet.ContentModel" version="3.4.3" targetFramework="net461" />
@@ -25,6 +32,7 @@
   <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net461" />
   <package id="NUnit.Runners" version="3.5.0" targetFramework="net461" />
   <package id="OpenCover" version="4.6.519" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="Serilog" version="2.3.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Serilog.Sinks.Literate" version="2.0.0" targetFramework="net452" />
   <package id="Serilog.Sinks.TextWriter" version="2.1.0" targetFramework="net452" />


### PR DESCRIPTION
Suppose you have this powershell snippet: `$env:myvar = "foo"`

Usage inside a yaml file:

    Description : "{{myvar"}}
    - tasks...

Description gets replaced with "foo"